### PR TITLE
Some improvements

### DIFF
--- a/TONX/Modules/Camouflague.cs
+++ b/TONX/Modules/Camouflague.cs
@@ -58,12 +58,6 @@ public static class Camouflage
             foreach (var pc in Main.AllPlayerControls)
             {
                 RpcSetSkin(pc);
-
-                // The code is intended to remove pets at dead players to combat a vanilla bug
-                if (!IsCamouflage && !pc.IsAlive())
-                {
-                    pc.RpcSetPet("");
-                }
             }
             Utils.NotifyRoles(NoCache: true);
         }

--- a/TONX/Modules/OptionBackup/OptionBackupData.cs
+++ b/TONX/Modules/OptionBackup/OptionBackupData.cs
@@ -19,6 +19,8 @@ public class OptionBackupData
         }
         foreach (BoolOptionNames name in EnumHelper.GetAllValues<BoolOptionNames>())
         {
+            if (name is BoolOptionNames.GhostsDoTasks) continue;
+
             if (option.TryGetBool(name, out var value))
                 AllValues.Add(new BoolOptionBackupValue(name, value));
         }

--- a/TONX/Modules/OptionBackup/OptionBackupValue.cs
+++ b/TONX/Modules/OptionBackup/OptionBackupValue.cs
@@ -33,7 +33,8 @@ public class BoolOptionBackupValue : OptionBackupValueBase<BoolOptionNames, bool
     public BoolOptionBackupValue(BoolOptionNames name, bool value) : base(name, value) { }
     public override void Restore(IGameOptions option)
     {
-        option.SetBool(OptionName, Value);
+        if (OptionName is not BoolOptionNames.GhostsDoTasks)
+            option.SetBool(OptionName, Value);
     }
 }
 public class FloatOptionBackupValue : OptionBackupValueBase<FloatOptionNames, float>

--- a/TONX/Modules/OptionHolder.cs
+++ b/TONX/Modules/OptionHolder.cs
@@ -96,6 +96,7 @@ public static class Options
 
     public static float DefaultKillCooldown = Main.NormalOptions?.KillCooldown ?? 20;
     public static OptionItem DefaultShapeshiftCooldown;
+    public static OptionItem GhostsDoTasks; //Fake optionitem to prevent game from loading it
 
     public static OptionItem DeadImpCantSabotage;
     public static OptionItem ImpKnowAlliesRole;

--- a/TONX/Modules/Utils.cs
+++ b/TONX/Modules/Utils.cs
@@ -1334,6 +1334,7 @@ public static class Utils
             1 => new(-11.4f, 8.2f), // MIRA HQ
             2 => new(42.6f, -19.9f), // Polus
             4 => new(-16.8f, -6.2f), // Airship
+            5 => new(10.2f, 18.1f), // The Fungle
             _ => throw new System.NotImplementedException(),
         };
     }

--- a/TONX/Patches/ClientOptionsPatch.cs
+++ b/TONX/Patches/ClientOptionsPatch.cs
@@ -47,7 +47,7 @@ public static class OptionsMenuBehaviourStartPatch
         }
         if (HorseMode == null || HorseMode.ToggleButton == null)
         {
-            HorseMode = ClientOptionItem.Create("HorseMode", Main.HorseMode, __instance, () => HorseModePatch.isHorseMode = !HorseModePatch.isHorseMode);
+            HorseMode = ClientOptionItem.Create("HorseMode", Main.HorseMode, __instance);
         }
         if (AutoStartGame == null || AutoStartGame.ToggleButton == null)
         {

--- a/TONX/Patches/HorseModePatch.cs
+++ b/TONX/Patches/HorseModePatch.cs
@@ -6,7 +6,7 @@ namespace TONX;
 [HarmonyPatch(typeof(Constants), nameof(Constants.ShouldHorseAround))]
 public static class HorseModePatch
 {
-    public static bool isHorseMode = false;
+    public static bool isHorseMode = Main.HorseMode.Value;
     public static bool Prefix(ref bool __result)
     {
         __result = isHorseMode;

--- a/TONX/Patches/PlayerContorolPatch.cs
+++ b/TONX/Patches/PlayerContorolPatch.cs
@@ -732,11 +732,6 @@ public static class PlayerControlDiePatch
 {
     public static void Postfix(PlayerControl __instance)
     {
-        if (AmongUsClient.Instance.AmHost)
-        {
-            // 死者の最終位置にペットが残るバグ対応
-            __instance.RpcSetPet("");
-        }
     }
 }
 [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.MixUpOutfit))]


### PR DESCRIPTION
1.Port anti ghostsdotasks from tohe+ 提高部分情况下的性能 目前卡顿貌似是由hudmanager里的roletext导致的
2.Add blackroom pos for fungle 在山顶
3.Horse mode set to be same with Main.horseMode 似乎没有必要进行赋值操作
4.Remove rpc set pet for dead player (AU官方在fungle更新解决了这个问题 并且rpcsetpet在大多数情况下对原版是无效的，在官方修复宠物问题前TOHE使用setpetstr发包来强制修改宠物)